### PR TITLE
Add Log Analysis section with SmartTune CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is a list of various resources related to drones, UAV's and quadcopters. It
   - [Firmware for Transmitters](#firmware-for-transmitters)
   - [Firmware for Flight Controllers](#firmware-for-flight-controllers)
   - [Libraries](#libraries)
+  - [Log Analysis](#log-analysis)
   - [Ground Control Stations](#ground-Control-Stations)
 - [Services](#services)
 - [Hardware and Components](#hardware-and-components)
@@ -99,6 +100,10 @@ This is a list of various resources related to drones, UAV's and quadcopters. It
 * [Libcyphal](https://github.com/OpenCyphal-Garage/libcyphal) - Portable reference implementation of the Cyphal protocol stack in C++ for embedded systems and Linux. Formerly known as LibUAVCAN.
 * [MAVLink](https://github.com/mavlink/mavlink) - Micro Air Vehicle Message Marshalling Library.
 * [MAVROS](https://github.com/mavlink/mavros) - MAVLink to ROS gateway with a proxy for Ground Control Station.
+
+### Log Analysis
+
+* [SmartTune CLI](https://github.com/raylanlin/smarttune-cli) - Multi-platform flight log analysis & tuning advisor for ArduPilot, Betaflight and PX4. Offline-first, designed for AI agents.
 
 ### Ground Control Stations
 


### PR DESCRIPTION
This PR adds a new "Log Analysis" subsection under "Software and Libraries", featuring SmartTune CLI — a multi-platform flight log analysis & tuning advisor for ArduPilot, Betaflight and PX4.

**Why it fits:**
- Open-source (MIT) flight log analysis tool
- Supports ArduPilot, Betaflight, and PX4 log formats with auto-detection
- Offline-first, zero cloud dependency
- Designed for both human CLI use and AI agent tool-calling

Per contribution guidelines:
- [x] Single suggestion per PR
- [x] Proper format: `[name](link) - Description.`
- [x] Alphabetical order within category
- [x] Capital start, period end
- [x] No trailing whitespace